### PR TITLE
(#8) Removed Special GitHub Actions

### DIFF
--- a/.github/workflows/commitlint.config.js
+++ b/.github/workflows/commitlint.config.js
@@ -5,6 +5,7 @@ module.exports = {
         /^\((#\d+(?:(?:, ){1}#\d+)*)+\)\s(.+)$/
       ),
       headerCorrespondence: ["references", "subject"],
+      referenceActions: null,
     }
   },
   plugins: [
@@ -40,6 +41,7 @@ module.exports = {
     "header-match-team-pattern": [2, "always"],
     "header-beware-commas": [1, "always"],
     "header-min-length": [2, "always", 20],
-    "header-max-length": [2, "always", 72]
+    "header-max-length": [2, "always", 72],
+    "body-leading-blank": [2, "always"],
   }
 };

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+commitlintcmd=$(which commitlint)
+
+if [ $? != 0 ]; then
+  echo "Please Install commitlint"
+  exit 1
+fi
+
+for f in ./tests/*.txt
+do
+  cat "$f" | $commitlintcmd -g ./.github/workflows/commitlint.config.js
+  if [ $? != 0 ]; then
+    echo "Test $f failed."
+  fi
+done
+

--- a/tests/bad.txt.hidden
+++ b/tests/bad.txt.hidden
@@ -1,0 +1,1 @@
+Blah Bl;ahs

--- a/tests/multi-line-commit-2.txt
+++ b/tests/multi-line-commit-2.txt
@@ -1,0 +1,4 @@
+(#3514) Blah holiday date check for proactive chat
+
+Change findObservedHoliday to use a copy of the passed object
+rather than modify the original.

--- a/tests/multi-line-commit.txt
+++ b/tests/multi-line-commit.txt
@@ -1,0 +1,4 @@
+(#3514) Fix holiday date check for proactive chat
+
+Change findObservedHoliday to use a copy of the passed object
+rather than modify the original.

--- a/tests/single-line-commit.txt
+++ b/tests/single-line-commit.txt
@@ -1,0 +1,1 @@
+(#1234) Some Short Message


### PR DESCRIPTION
- Words like Fix or Closes have special meaning. Turned this off.
- Also made a quick and dirty tester. We can add more test cases in the future. Maybe even make a GH workflow for the workflow. NOTE: bad.txt.hidden can be renamed to bad.txt to make sure it still checks bad commits. One commit message per file.